### PR TITLE
Add affected versions outside vstinner/python-security

### DIFF
--- a/advisories/python/PSF-2023-1.json
+++ b/advisories/python/PSF-2023-1.json
@@ -19,6 +19,9 @@
             },
             {
               "fixed": "72d356e3584ebfb8e813a8e9f2cd3dccf233c0d9"
+            },
+            {
+              "fixed": "439b9cfaf43080e91c4ad69f312f21fa098befc7"
             }
           ],
           "repo": "https://github.com/python/cpython"

--- a/advisories/python/PSF-2023-2.json
+++ b/advisories/python/PSF-2023-2.json
@@ -9,10 +9,24 @@
   "summary": "Parsing errors in email/_parseaddr.py lead to incorrect value in email address part of tuple",
   "details": "The email module of Python through 3.11.3 incorrectly parses e-mail addresses that contain a special character. The wrong portion of an RFC2822 header is identified as the value of the addr-spec. In some applications, an attacker can bypass a protection mechanism in which application access is granted only after verifying receipt of e-mail to a specific domain (e.g., only @company.example.com addresses may be used for signup). This occurs in email/_parseaddr.py in recent versions of Python.",
   "affected": [
-    {}
+    {
+      "ranges": [
+        {
+          "type": "GIT",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "repo": "https://github.com/python/cpython"
+        }
+      ]
+    }
   ],
   "database_specific": {
-    "cwe_ids": []
+    "cwe_ids": [
+      "CWE-20"
+    ]
   },
   "references": [
     {

--- a/advisories/python/PSF-2023-3.json
+++ b/advisories/python/PSF-2023-3.json
@@ -8,9 +8,37 @@
   ],
   "details": "CPython v3.12.0 alpha 7 was discovered to contain a heap use-after-free via the function ascii_decode at /Objects/unicodeobject.c.",
   "affected": [
-    {}
+    {
+      "ranges": [
+        {
+          "type": "GIT",
+          "events": [
+            {
+              "introduced": "1ef61cf71a218c71860ff6aecf0fd51edb8b65dc"
+            },
+            {
+              "fixed": "d5a97074d24cd14cb2a35a2b1ad3074863cde264"
+            }
+          ],
+          "repo": "https://github.com/python/cpython"
+        },
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.12.0a7"
+            },
+            {
+              "fixed": "3.12.0b1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "database_specific": {
-    "cwe_ids": []
+    "cwe_ids": [
+      "CWE-416"
+    ]
   }
 }

--- a/advisories/python/PSF-2023-4.json
+++ b/advisories/python/PSF-2023-4.json
@@ -8,9 +8,31 @@
   ],
   "details": "The legacy email.utils.parseaddr function in Python through 3.11.4 allows attackers to trigger \"RecursionError: maximum recursion depth exceeded while calling a Python object\" via a crafted argument. This argument is plausibly an untrusted value from an application's input data that was supposed to contain a name and an e-mail address. NOTE: email.utils.parseaddr is categorized as a Legacy API in the documentation of the Python email package. Applications should instead use the email.parser.BytesParser or email.parser.Parser class. NOTE: the vendor's perspective is that this is neither a vulnerability nor a bug. The email package is intended to have size limits and to throw an exception when limits are exceeded; they were exceeded by the example demonstration code.",
   "affected": [
-    {}
+    {
+      "ranges": [
+        {
+          "type": "GIT",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ],
+          "repo": "https://github.com/python/cpython"
+        },
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "database_specific": {
-    "cwe_ids": []
+    "cwe_ids": [
+      "CWE-674"
+    ]
   }
 }


### PR DESCRIPTION
Adds affected versions to CVE IDs that aren't covered in vstinner/python-security.