### PR TITLE
Remove ecosystem tags from affected field

### DIFF
--- a/advisories/python/PSF-2023-10.json
+++ b/advisories/python/PSF-2023-10.json
@@ -1,10 +1,11 @@
 {
-  "modified": "2023-08-28T14:03:06Z",
+  "modified": "2023-08-28T16:57:11Z",
   "published": "2023-08-22T00:00:00Z",
   "schema_version": "1.5.0",
   "id": "PSF-2023-10",
   "aliases": [
-    "CVE-2022-48564"
+    "CVE-2022-48564",
+    "GHSA-p8vw-m6qq-w42v"
   ],
   "summary": "DoS when reading malformed Apple Property List files in binary format",
   "details": "read_ints in plistlib.py in Python through 3.9.1 is vulnerable to a potential DoS attack via CPU and RAM exhaustion when processing malformed Apple Property List files in binary format.",
@@ -47,6 +48,12 @@
     {
       "type": "FIX",
       "url": "https://github.com/python/cpython/pull/22882"
+    }
+  ],
+  "credits": [
+    {
+      "type": "REPORTER",
+      "name": "Samuel Henrique"
     }
   ],
   "database_specific": {

--- a/advisories/python/PSF-2023-11.json
+++ b/advisories/python/PSF-2023-11.json
@@ -1,10 +1,11 @@
 {
-  "modified": "2023-08-28T14:03:06Z",
+  "modified": "2023-08-28T16:57:11Z",
   "published": "2023-08-22T00:00:00Z",
   "schema_version": "1.5.0",
   "id": "PSF-2023-11",
   "aliases": [
-    "CVE-2022-48560"
+    "CVE-2022-48560",
+    "GHSA-pvw5-cvp6-cv92"
   ],
   "summary": "Use-after-free in heappushpop() of heapq module",
   "details": "A use-after-free exists in Python through 3.9 via heappushpop in heapq.",
@@ -47,6 +48,12 @@
     {
       "type": "FIX",
       "url": "https://github.com/python/cpython/pull/18118"
+    }
+  ],
+  "credits": [
+    {
+      "type": "REPORTER",
+      "name": "Samuel Henrique"
     }
   ],
   "database_specific": {

--- a/advisories/python/PSF-2023-3.json
+++ b/advisories/python/PSF-2023-3.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2023-06-07T00:00:00Z",
+  "modified": "2023-08-28T16:57:11Z",
   "published": "2023-06-07T00:00:00Z",
   "schema_version": "1.5.0",
   "id": "PSF-2023-3",
@@ -21,17 +21,6 @@
             }
           ],
           "repo": "https://github.com/python/cpython"
-        },
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "3.12.0a7"
-            },
-            {
-              "fixed": "3.12.0b1"
-            }
-          ]
         }
       ]
     }

--- a/advisories/python/PSF-2023-4.json
+++ b/advisories/python/PSF-2023-4.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2023-06-29T00:00:00Z",
+  "modified": "2023-08-28T16:57:11Z",
   "published": "2023-06-25T00:00:00Z",
   "schema_version": "1.5.0",
   "id": "PSF-2023-4",
@@ -18,14 +18,6 @@
             }
           ],
           "repo": "https://github.com/python/cpython"
-        },
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
         }
       ]
     }

--- a/advisories/python/PSF-2023-5.json
+++ b/advisories/python/PSF-2023-5.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2023-08-24T00:00:00Z",
+  "modified": "2023-08-28T16:57:11Z",
   "published": "2023-08-24T00:00:00Z",
   "schema_version": "1.5.0",
   "id": "PSF-2023-5",
@@ -35,41 +35,6 @@
             }
           ],
           "repo": "https://github.com/python/cpython"
-        },
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "3.6.15"
-            },
-            {
-              "introduced": "3.7.0"
-            },
-            {
-              "fixed": "3.7.17"
-            },
-            {
-              "introduced": "3.8.0"
-            },
-            {
-              "fixed": "3.8.7"
-            },
-            {
-              "introduced": "3.9.0"
-            },
-            {
-              "fixed": "3.9.1"
-            },
-            {
-              "introduced": "3.10.0a1"
-            },
-            {
-              "fixed": "3.10.0a2"
-            }
-          ]
         }
       ]
     }

--- a/advisories/python/PSF-2023-6.json
+++ b/advisories/python/PSF-2023-6.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2023-08-24T00:00:00Z",
+  "modified": "2023-08-28T16:57:11Z",
   "published": "2023-08-24T00:00:00Z",
   "schema_version": "1.5.0",
   "id": "PSF-2023-6",
@@ -35,41 +35,6 @@
             }
           ],
           "repo": "https://github.com/python/cpython"
-        },
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "3.6.13"
-            },
-            {
-              "introduced": "3.7.0"
-            },
-            {
-              "fixed": "3.7.10"
-            },
-            {
-              "introduced": "3.8.0"
-            },
-            {
-              "fixed": "3.8.7"
-            },
-            {
-              "introduced": "3.9.0"
-            },
-            {
-              "fixed": "3.9.1"
-            },
-            {
-              "introduced": "3.10.0a1"
-            },
-            {
-              "fixed": "3.10.0a3"
-            }
-          ]
         }
       ]
     }

--- a/advisories/python/PSF-2023-7.json
+++ b/advisories/python/PSF-2023-7.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2023-08-25T16:05:33Z",
+  "modified": "2023-08-28T16:57:11Z",
   "published": "2023-08-15T00:00:00Z",
   "schema_version": "1.5.0",
   "id": "PSF-2023-7",
@@ -26,17 +26,6 @@
             }
           ],
           "repo": "https://github.com/python/cpython"
-        },
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "3.12.0b1"
-            },
-            {
-              "fixed": "3.12.0rc2"
-            }
-          ]
         }
       ]
     }

--- a/advisories/python/PSF-2023-8.json
+++ b/advisories/python/PSF-2023-8.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2023-08-25T16:05:33Z",
+  "modified": "2023-08-28T16:57:11Z",
   "published": "2023-08-24T00:00:00Z",
   "schema_version": "1.5.0",
   "id": "PSF-2023-8",
@@ -37,41 +37,6 @@
             }
           ],
           "repo": "https://github.com/python/cpython"
-        },
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "3.8.18"
-            },
-            {
-              "introduced": "3.9.0"
-            },
-            {
-              "fixed": "3.9.18"
-            },
-            {
-              "introduced": "3.10.0"
-            },
-            {
-              "fixed": "3.10.13"
-            },
-            {
-              "introduced": "3.11.0"
-            },
-            {
-              "fixed": "3.11.5"
-            },
-            {
-              "introduced": "3.12.0a1"
-            },
-            {
-              "fixed": "3.12.0rc2"
-            }
-          ]
         }
       ]
     }

--- a/advisories/python/PSF-2023-9.json
+++ b/advisories/python/PSF-2023-9.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2023-08-25T16:05:33Z",
+  "modified": "2023-08-28T16:57:11Z",
   "published": "2023-08-24T00:00:00Z",
   "schema_version": "1.5.0",
   "id": "PSF-2023-9",
@@ -28,23 +28,6 @@
             }
           ],
           "repo": "https://github.com/python/cpython"
-        },
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "3.11.0"
-            },
-            {
-              "fixed": "3.11.5"
-            },
-            {
-              "introduced": "3.12.0a1"
-            },
-            {
-              "fixed": "3.12.0rc2"
-            }
-          ]
         }
       ]
     }

--- a/tools/import-historical-advisories.py
+++ b/tools/import-historical-advisories.py
@@ -1,6 +1,5 @@
 """Tool which imports data about historical CVEs for scoped projects"""
 import re
-import typing
 
 import urllib3
 import yaml
@@ -16,6 +15,8 @@ historical_cve_ids = {
         "CVE-2022-488565",
         "CVE-2022-488566",
         "CVE-2023-38898",
+        "CVE-2022-48560",
+        "CVE-2022-48564",
         # List of CVE IDs was taken from https://github.com/vstinner/python-security
         "CVE-2007-4965",
         "CVE-2008-1679",

--- a/tools/osv_utils.py
+++ b/tools/osv_utils.py
@@ -24,13 +24,18 @@ PRODUCT_TO_OSV_PACKAGE = {
     },
 }
 OSV_TEMPLATE = {
+    "modified": NOW_UTC,
+    "published": NOW_UTC,
     "schema_version": OSV_SCHEMA_VERSION,
+    "id": None,
+    "aliases": [],
     "affected": [
         {
             "ranges": [],
         }
     ],
     "references": [],
+    "credits": [],
     "database_specific": {"cwe_ids": []},
 }
 PRODUCT_TO_REPO = {
@@ -62,7 +67,6 @@ def update_osv_record(
     modified: str | None = None,
     cwe_ids: None | list[str] = None,
     affected_ranges_git: None | list[tuple[str, str]] = None,
-    affected_ranges_ecosystem: None | list[tuple[str, str]] = None,
     references: None | list[tuple[str, str]] = None,
 ):
     osv_filedir = ADVISORIES_DIR / product
@@ -154,29 +158,6 @@ def update_osv_record(
             for key, val in sorted(
                 new_events, key=lambda kv: (kv[0] != "introduced",) + kv
             )
-        ]
-
-    if affected_ranges_ecosystem:
-        ecosystem_range = get_osv_range(
-            osv,
-            range_type="ECOSYSTEM",
-            range_default={"type": "ECOSYSTEM", "events": []},
-        )
-        current_events = [list(event.items())[0] for event in ecosystem_range["events"]]
-        new_events = set(current_events) | set(affected_ranges_ecosystem)
-
-        # If there's no 'introduced' key we add an ('introduced', '0.0.0')
-        if not any(action == "introduced" for action, _ in new_events):
-            new_events.add(("introduced", "0.0.0"))
-
-        def ecosystem_sort_key(action_and_version):
-            action, version = action_and_version
-            # Ties on the version will go to whether the action is 'fixed' or 'introduced'.
-            # We want 'fixed' to always go after 'introduced'.
-            return (packaging.version.Version(version), action == "fixed")
-
-        ecosystem_range["events"] = [
-            {key: val} for key, val in sorted(new_events, key=ecosystem_sort_key)
         ]
 
     # Update the modified time if the content has changed at all.


### PR DESCRIPTION
Related to https://github.com/google/osv.dev/issues/1552, we can't use the `type: ECOSYSTEM` ranges if we don't supply an affected package, but we can't supply one because Python source exists outside a packaging ecosystem.

Perhaps we can explore using the `affected[].versions` field and listing all tags that are affected?