### PR TITLE
Add a fixed commit for PSF-2023-2

### DIFF
--- a/advisories/python/PSF-2023-2.json
+++ b/advisories/python/PSF-2023-2.json
@@ -16,6 +16,9 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "4a153a1d3b18803a684cd1bcc2cdf3ede3dbae19"
             }
           ],
           "repo": "https://github.com/python/cpython"


### PR DESCRIPTION
This commit was merged in https://github.com/python/cpython/pull/111116, the backport to 3.12 was reverted.