### PR TITLE
chore: Pin ID generation dependency

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         go-version: '^1.16.4'
     - run: |
-        go install github.com/google/osv/vulnfeeds/cmd/ids@latest
+        go install github.com/google/osv/external/cmd/ids@v0.0.0-20260525013352-508446a947cf
         ids -dir=./advisories -prefix PSF -format json
         git config user.name github-actions
         git config user.email github-actions@github.com


### PR DESCRIPTION
We (osv) are moving our externally depended upon code into its own top level folder and module for better and clearer maintainability. This PR points directly to the newly isolated /external directory for id generation and pins it to a specific, stable Go pseudo-version.